### PR TITLE
Remove warning flag for unjoinable rides

### DIFF
--- a/open_container/templates/view_event.html
+++ b/open_container/templates/view_event.html
@@ -52,7 +52,7 @@ class="btn btn-xs btn-danger">Leave Ride</button></td>
                     {% if ride['driver'] == user %}
                         <td><button type="button" onclick="deleteRide({{ride['id']}}, {{event}})", class="btn btn-xs btn-danger">Delete Ride</button>
                     {% elif driverId != 0 or inRides|length > 0 and ride['id'] not in inRides%}
-                        <td><span class="label label-danger">Can Only Join One Ride At Once</span>
+                        <td>
                     {% else %}
                         {% if ride['passengers']|length >= ride['capacity'] %}
                             <td><span class="label label-danger">Ride Full</span>


### PR DESCRIPTION
Removing the button altogether makes it easier for users to find the button most relevant to them if they would like to join a different ride.

Original: 
![image](https://cloud.githubusercontent.com/assets/1028704/19833463/413028fc-9e10-11e6-9bd9-84b78446d8bc.png)
This PR:
![image](https://cloud.githubusercontent.com/assets/1028704/19833474/7824b9cc-9e10-11e6-858f-66848b41d11b.png)
